### PR TITLE
Remove type pirated `promote_rule`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LazyJSON"
 uuid = "fc18253b-5e1b-504c-a4a2-9ece4944c004"
 license = "MIT"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/SplicedStrings.jl
+++ b/src/SplicedStrings.jl
@@ -61,11 +61,6 @@ function splice_item(ss::SubString{SplicedString})
                 [SubString(j_f, 1, j_i)])
 end
 
-
-#https://github.com/JuliaLang/julia/issues/26200
-Base.promote_rule(::Type{<:AbstractString},
-                  ::Type{<:AbstractString}) = AbstractString
-
 #https://github.com/JuliaLang/julia/issues/26202
 Base.nextind(s::SubString{SplicedString}, i::Int) = nextind(s.string, i)
 Base.prevind(s::SubString{SplicedString}, i::Int) = prevind(s.string, i)


### PR DESCRIPTION
I discovered this type piracy when using CategoricalArrays and LazyJSON together:
```julia
julia> using LazyJSON, CategoricalArrays

julia> promote_rule(CategoricalString{UInt32}, String)
ERROR: MethodError: promote_rule(::Type{CategoricalString{UInt32}}, ::Type{String}) is ambiguous. Candidates:
  promote_rule(::Type{#s13} where #s13<:AbstractString, ::Type{#s12} where #s12<:AbstractString) in LazyJSON.SplicedStrings at /Users/omus/.julia/packages/LazyJSON/nq0s6/src/SplicedStrings.jl:67
  promote_rule(::Type{C}, ::Type{T}) where {C<:(Union{CategoricalString{R}, CategoricalValue{T,R} where T} where R), T} in CategoricalArrays at /Users/omus/.julia/packages/CategoricalArrays/dmrjI/src/value.jl:74
Possible fix, define
  promote_rule(::Type{C<:(CategoricalString{R} where R)}, ::Type{T<:AbstractString})
```
This [particular rule](https://github.com/JuliaCloud/LazyJSON.jl/blob/cb3813802e365ed163f745b2096a4c574f22ea60/src/SplicedStrings.jl#L66) appears to have been added to make `SplicedString` more performant (see [comment](https://github.com/JuliaLang/julia/issues/26200#issuecomment-368350007)). It appears in the time since that comment `SplicedString` no longer contains a `Vector{AbstractArray}` but rather a `Vector{SubString{String}}` making the rule unnecessary.